### PR TITLE
Update URL in userkeys.cfg

### DIFF
--- a/config/userkeys.cfg
+++ b/config/userkeys.cfg
@@ -1,6 +1,6 @@
 NB. userkeys.cfg
 NB.
-NB. See wiki page code.jsoftware.com/wiki/Guides/Config/JQt/UserKeys
+NB. See wiki page https://code.jsoftware.com/wiki/Guides/Qt_IDE/Configure/User_Keys
 NB.
 NB. Examples:
 NB.  F3;1;Minesweeper;load '~addons/games/minesweeper/uiwd.ijs'


### PR DESCRIPTION
I searched the wiki for information on keyboard shortcuts. Then noted that the IDE provides the URL of the wiki page. However, that link was not up-to-date. This now points to correct location.