### PR TITLE
override default echo to invoke jqt's message pump

### DIFF
--- a/qt.ijs
+++ b/qt.ijs
@@ -90,6 +90,7 @@ end.
 'title caption text'=. _3 {. p
 wd 'textview *;',title,';',caption,';',flatten text
 )
+echo_z_=: wd@'msgs'^:2 [ 1!:2&2
 addons_msg=: 0 : 0
 The XX are not yet installed.
 

--- a/source/main/util.ijs
+++ b/source/main/util.ijs
@@ -113,3 +113,7 @@ end.
 'title caption text'=. _3 {. p
 wd 'textview *;',title,';',caption,';',flatten text
 )
+
+NB. =========================================================
+NB. override default echo to invoke jqt's message pump
+echo_z_=: wd@'msgs'^:2 [ 1!:2&2


### PR DESCRIPTION
Currently, jqt obtains efficiency by defering screen updates until the keyboard unlocks for input.

This is not desirable in the context of the definition of echo as defined in stdlib.ijs

Currently, the message pump needs two cycles to put text on the screen.